### PR TITLE
Bump geoserver version from 2.25.3 to 2.25.5

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -59,7 +59,7 @@ services:
 
   geoserver:
     container_name: ${COMPOSE_PROJECT_NAME}-geoserver
-    image: docker.osgeo.org/geoserver:2.25.3
+    image: docker.osgeo.org/geoserver:2.25.5
     environment:
       SKIP_DEMO_DATA: true
       GEOSERVER_CSRF_WHITELIST: ${HOST}


### PR DESCRIPTION
update to latest patch version, note this is likely the last or second to last patch version in the 2.25.x branch, upgrading to 2.26.x or 2.27.x is imminent.

see also:
- https://geoserver.org/announcements/vulnerability/2024/10/29/geoserver-2-25-4-released.html
- https://geoserver.org/announcements/2024/12/18/geoserver-2-25-5-released.html