### PR TITLE
Allow setting PMW api version for compose deployment

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -35,7 +35,7 @@ services:
 
   pmw-api:
     container_name: ${COMPOSE_PROJECT_NAME}-pmw-api
-    image: ghcr.io/b3partners/planmonitor-wonen-api:snapshot
+    image: ghcr.io/b3partners/planmonitor-wonen-api:${PMW_API_VERSION:-snapshot}
     restart: unless-stopped
     depends_on:
       pmw-db:


### PR DESCRIPTION
set PMW_API_VERSION to a release version, eg. 1.0.0 to deploy that specific version/tag of the API. 

See also: https://github.com/B3Partners/planmonitor-wonen-api/pkgs/container/planmonitor-wonen-api for available versions